### PR TITLE
Bump fqdn to 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aioredis==1.2.0
 async-timeout==3.0.1
 cached-property==1.5.1
 cffi==1.12.3
-fqdn==1.1.0
+fqdn==1.2.0
 hiredis==1.0.0
 pycares==3.0.0
 pycparser==2.19


### PR DESCRIPTION
I released a new minor version of `fqdn` today on PyPI that fixes corner use cases:
- allow numbers and dashes in labels after the first + tests
- 63 octet labels + tests

https://pypi.org/project/fqdn/1.2.0/
http://github.com/ypcrts/fqdn